### PR TITLE
Fetches similar documents from the vector db

### DIFF
--- a/src/services/retrievalService.js
+++ b/src/services/retrievalService.js
@@ -3,12 +3,13 @@ import { supabase } from '../config/supabase.js';
 export async function getRelevantDocuments(embedding) {
   try {
     const { data, error } = await supabase.rpc('match_documents', {
+      filter: null,
       query_embedding: embedding,
       match_count: 3, // Top 3 relevant documents
     });
 
     if (error) throw error;
-    return data.map(doc => doc.text).join("\n"); // Combine results
+    return data.map(doc => doc.content).join("\n"); // Combine results
   } catch (error) {
     console.error('Error retrieving documents:', error);
     throw error;


### PR DESCRIPTION
Fixing a small bug in `src/services/retrievalService.js`. We need to add `filter: null` to our query to `match_documents` since that is a required param in Supabase, otherwise, no results will be shown. 
Here's a brief snippet we can use to test it via the Node REPL (make sure you're inside the /src folder):

```
const { getRelevantDocuments } = await import("./services/retrievalService.js")
const { generateEmbedding } = await import("./services/embeddingService.js")
const { generateAnswer } = await import("./services/inferenceService.js")
const { supabase } = await import("./config/supabase.js");

const Body = "a nossa endometriose e politica. vamos lutar juntas pelos nossos direitos? # naomatatortura por hannah parnes oi! e um prazer te conhecer. este aqui e um espaco para mostrar para voces um pouco da minha luta contra a endometriose e para construir uma"
let result = await generateEmbedding(Body)
let relevantDocuments = await getRelevantDocuments(result)
console.log(relevantDocuments)
```


